### PR TITLE
Fix crash on MAUI Android

### DIFF
--- a/src/Serilog.Sinks.SQLite/LoggerConfigurationSQLiteExtensions.cs
+++ b/src/Serilog.Sinks.SQLite/LoggerConfigurationSQLiteExtensions.cs
@@ -70,12 +70,8 @@ namespace Serilog
                 throw new ArgumentNullException(nameof(sqliteDbPath));
             }
 
-            if (!Uri.TryCreate(sqliteDbPath, UriKind.RelativeOrAbsolute, out var sqliteDbPathUri)) {
-                throw new ArgumentException($"Invalid path {nameof(sqliteDbPath)}");
-            }
-
-            if (!sqliteDbPathUri.IsAbsoluteUri) {
-                var basePath = System.Reflection.Assembly.GetEntryAssembly().Location;
+            if (!Path.IsPathRooted(sqliteDbPath)) {
+                var basePath = (System.Reflection.Assembly.GetEntryAssembly() ?? System.Reflection.Assembly.GetExecutingAssembly()).Location;
                 sqliteDbPath = Path.Combine(Path.GetDirectoryName(basePath) ?? throw new NullReferenceException(), sqliteDbPath);
             }
 


### PR DESCRIPTION
It is a serious mistake to use URI logic for pure filesystem paths. Those clearly do not model the same type of information. In some cases, this library becomes unusable.

- `System.Reflection.Assembly.GetEntryAssembly` has a return type of `System.Reflection.Assembly?`, reminding the caller that it might be `null`.
- On some platforms, such as on .NET MAUI on Android, `System.Reflection.Assembly.GetEntryAssembly()` always returns `null`, which means that any attempt to access its `Location` always crashes.
- On *nix systems an absolute filesystem path is never recognisable as an absolute `Uri`. If I treat `/data/…` as a `Uri` it's clearly a relative URI. However it's an absolute filesystem path.

As a consequence, on MAUI Android (and possibly MAUI iOS) the absolute URI append cannot be avoided, and will always crash.

I propose to fix three things:

- Remove the URI parsing. It's categorically wrong. Additionally it's unnecessary as [this stackoverflow](https://stackoverflow.com/questions/6198392/check-whether-a-path-is-valid) confirms. The call to `new FileInfo()` already executed slightly later is a much better check to see whether a _path_ is correct.
- Use a null-coalesce with the non-nullable `System.Reflection.Assembly.GetExecutingAssembly()` to prevent the crash.
- Use the probably more correct `Path.IsPathRooted()`. Note that this doesn't mean the path is _absolute_. However I think that you didn't actually mean to prepend on _every_ relative path. On *nix systems this would not cause problems, but on Windows systems the path `\Windows` is both rooted _and_ relative. That is because if your current working directory is on the `C:` drive, `\Windows` means `C:\Windows` and when working on the `D:` drive it means `D:\Windows`. I think that in this case it is clear that to prepend a path would be erroneous either way.

These changes make that I can use this library in .NET MAUI. Otherwise it would always crash at initialisation.